### PR TITLE
provide an implicit instance for NewRelicRequestTimer

### DIFF
--- a/newrelic/src/main/scala/org/lyranthe/http4s/timer/newrelic/package.scala
+++ b/newrelic/src/main/scala/org/lyranthe/http4s/timer/newrelic/package.scala
@@ -1,0 +1,8 @@
+package org.lyranthe.http4s.timer
+
+import cats.effect.Sync
+
+package object newrelic {
+  implicit def newRelicRequestTimer[F[_]: Sync]: NewRelicRequestTimer[F] =
+    new NewRelicRequestTimer[F]
+}


### PR DESCRIPTION
After upgrading to version *0.0.4* of this library from *0.0.3* we've had to create a new implicit instance of *NewRelicRequestTimer* to get our code to compile. This is not what we expected for a dot point release - we expect no breaking changes.

This is similar to what was removed in https://github.com/fiadliel/http4s-timer/commit/dae2f89e83a10d8b162d01926e96ceef1eee5a81#diff-949cc140d2c5ad63d3a141c8e2656d75. Not sure why it was removed?

This PR creates an implicit instance of *NewRelicRequestTimer* which can be imported as per the instructions in the README:

```
import org.lyranthe.http4s.timer._
import org.lyranthe.http4s.timer.newrelic._
```

As such it should not have any breaking changes for clients moving from *0.0.3* to *0.0.4*.

